### PR TITLE
Skip building src on non-linux targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,8 @@
 fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS") == Ok("macos".to_string()) {
+        return;
+    }
+
     println!("cargo:rustc-link-lib=cpg");
     println!("cargo:rustc-link-lib=cfg");
     println!("cargo:rustc-link-lib=cmap");


### PR DESCRIPTION
This allows compilation for testing to complete on non-linux targets.

This is useful when integrating this crate into larger projects, where we still want to test locally before pushing to CI (on a macos host for instance).

Signed-off-by: Joe Grund <jgrund@whamcloud.io>